### PR TITLE
default to mysql2 adapter

### DIFF
--- a/lib/spatial_adapter/railtie.rb
+++ b/lib/spatial_adapter/railtie.rb
@@ -1,7 +1,8 @@
 module SpatialAdapter
   class Railtie < Rails::Railtie
     initializer "spatial_adapter.load_current_database_adapter" do
-      adapter = ActiveRecord::Base.configurations[Rails.env]['adapter']
+      adapter = 'mysql2'
+
       begin
         require "spatial_adapter/#{adapter}"
       rescue LoadError


### PR DESCRIPTION
This is where the railtie breaks on the heroku deploy. We're using mysql2 for this, so we can just hard code the adapter value.

@bellycard/platform 
